### PR TITLE
removed second config print

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -27,13 +27,6 @@ if [ -z "${bundle_version_short}" ] ; then
 fi
 
 # ---------------------
-# --- Configs:
-
-echo " (i) Provided Info.plist file path: ${info_plist_file}"
-echo " (i) Provided Bundle Version: ${bundle_version}"
-echo " (i) Provided Bundle Short Version String: ${bundle_version_short}"
-
-# ---------------------
 # --- Main:
 
 # verbose / debug print commands


### PR DESCRIPTION
Is neccessary to print out the config two times?
Most of times we print out the config before any validation, this case when any validation fails, user can check out the provided config and correct every issues (if any).
